### PR TITLE
Add Politica (Privacy Policy) page and app routing with redirects

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,7 +1,14 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import { HomeComponent } from './page/home/home.component';
+import { PoliticaComponent } from './components/politica/politica.component';
 
-const routes: Routes = [];
+const routes: Routes = [
+  { path: '', component: HomeComponent },
+  { path: 'politica', component: PoliticaComponent },
+  { path: 'politoca', redirectTo: 'politica', pathMatch: 'full' },
+  { path: '**', redirectTo: '', pathMatch: 'full' }
+];
 
 @NgModule({
   imports: [RouterModule.forRoot(routes)],

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,1 +1,1 @@
-<app-home></app-home>
+<router-outlet></router-outlet>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -9,6 +9,7 @@ import { ApresentacaoComponent } from './components/apresentacao/apresentacao.co
 import { ProjetoDireitaComponent } from './components/projeto-direita/projeto-direita.component';
 import { HomeComponent } from './page/home/home.component';
 import { ModalImgComponent } from './components/modal-img/modal-img.component';
+import { PoliticaComponent } from './components/politica/politica.component';
 
 @NgModule({
   declarations: [
@@ -17,7 +18,8 @@ import { ModalImgComponent } from './components/modal-img/modal-img.component';
     ApresentacaoComponent,
     ProjetoDireitaComponent,
     HomeComponent,
-    ModalImgComponent
+    ModalImgComponent,
+    PoliticaComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/politica/politica.component.html
+++ b/src/app/components/politica/politica.component.html
@@ -1,0 +1,77 @@
+<section class="politica">
+  <h1>📄 Política de Privacidade – HoverTraduz</h1>
+  <p class="date"><strong>Última atualização:</strong> {{ updatedAt }}</p>
+
+  <p>
+    O <strong>HoverTraduz</strong> é uma extensão de navegador que traduz textos no hover e converte moedas em páginas da web,
+    sem substituir o conteúdo original.
+  </p>
+
+  <h2>1️⃣ Quem somos</h2>
+  <p><strong>Nome do produto:</strong> HoverTraduz</p>
+  <p><strong>Contato de suporte:</strong> suporte@jrweb.com.br</p>
+
+  <h2>2️⃣ Dados que processamos</h2>
+  <p>
+    O HoverTraduz <strong>não coleta dados pessoais identificáveis</strong> (como nome, e-mail, telefone, CPF, etc.)
+    para venda ou perfilamento.
+  </p>
+  <p>Para funcionar, a extensão pode processar:</p>
+  <ul>
+    <li>Trechos de texto visível da página (para tradução no hover)</li>
+    <li>Valores de preço (para conversão de moeda)</li>
+    <li>Preferências do usuário (idioma, moeda e opções da extensão)</li>
+    <li>Cache técnico local para melhorar desempenho</li>
+  </ul>
+
+  <h2>3️⃣ Como usamos esses dados</h2>
+  <p>Os dados processados são usados exclusivamente para:</p>
+  <ul>
+    <li>Mostrar tradução de texto no hover</li>
+    <li>Exibir conversão de moeda ao lado dos preços</li>
+    <li>Salvar configurações escolhidas pelo usuário</li>
+    <li>Reduzir requisições repetidas via cache</li>
+  </ul>
+
+  <h2>4️⃣ Compartilhamento com terceiros</h2>
+  <p>
+    Quando a tradução online estiver habilitada, trechos de texto podem ser enviados a provedores externos de tradução
+    para gerar o resultado.
+  </p>
+  <p>A extensão também pode consultar provedores de cotação para conversão de moeda.</p>
+  <p>✅ <strong>O HoverTraduz não vende dados de usuários.</strong></p>
+
+  <h2>5️⃣ Armazenamento e retenção</h2>
+  <p>
+    As preferências e o cache técnico são armazenados localmente no navegador (ex.: armazenamento da extensão).
+  </p>
+  <p>
+    Esses dados permanecem até serem sobrescritos, limpos pelo navegador ou removidos com a desinstalação da extensão.
+  </p>
+
+  <h2>6️⃣ Segurança</h2>
+  <p>
+    Adotamos medidas para minimizar o processamento de dados e limitar o uso ao objetivo principal da extensão.
+  </p>
+
+  <h2>7️⃣ Seus direitos</h2>
+  <p>Você pode:</p>
+  <ul>
+    <li>Desativar recursos da extensão</li>
+    <li>Remover a extensão a qualquer momento</li>
+    <li>Limpar os dados locais pelo navegador</li>
+  </ul>
+
+  <h2>8️⃣ Crianças e menores</h2>
+  <p>
+    A extensão não é direcionada especificamente a crianças e não busca coletar dados pessoais de menores.
+  </p>
+
+  <h2>9️⃣ Alterações nesta política</h2>
+  <p>Esta Política de Privacidade pode ser atualizada periodicamente.</p>
+  <p>A versão mais recente estará sempre disponível nesta mesma URL.</p>
+
+  <h2>🔟 Contato</h2>
+  <p>Se tiver dúvidas sobre esta política, entre em contato:</p>
+  <p>📧 suporte@jrweb.com.br</p>
+</section>

--- a/src/app/components/politica/politica.component.scss
+++ b/src/app/components/politica/politica.component.scss
@@ -1,0 +1,63 @@
+.politica {
+  max-width: 920px;
+  margin: 2.5rem auto;
+  padding: 2rem 1.8rem 2.5rem;
+  background: #0f1116;
+  border: 1px solid #232632;
+  border-radius: 14px;
+  box-shadow: 0 10px 35px rgba(0, 0, 0, 0.35);
+  color: #f6f7fb;
+
+  h1 {
+    margin-bottom: 1rem;
+    font-size: clamp(1.6rem, 2.2vw, 2.05rem);
+    line-height: 1.3;
+    color: #ffffff;
+  }
+
+  h2 {
+    margin: 1.8rem 0 0.65rem;
+    font-size: 1.2rem;
+    line-height: 1.4;
+    color: #f0f3ff;
+  }
+
+  p,
+  li {
+    line-height: 1.75;
+    font-size: 1rem;
+    color: #d7dbe8;
+  }
+
+  p {
+    margin-bottom: 0.85rem;
+  }
+
+  ul {
+    margin: 0.35rem 0 1rem 1.2rem;
+    padding: 0;
+  }
+
+  strong {
+    color: #ffffff;
+  }
+
+  .date {
+    margin-bottom: 1.5rem;
+    font-size: 0.95rem;
+    color: #aab1c5;
+  }
+}
+
+@media (max-width: 768px) {
+  .politica {
+    margin: 1.25rem 0.75rem;
+    padding: 1.2rem 1rem 1.6rem;
+    border-radius: 10px;
+
+    p,
+    li {
+      font-size: 0.96rem;
+    }
+  }
+}

--- a/src/app/components/politica/politica.component.ts
+++ b/src/app/components/politica/politica.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-politica',
+  templateUrl: './politica.component.html',
+  styleUrls: ['./politica.component.scss']
+})
+export class PoliticaComponent {
+  updatedAt = '01/03/2026';
+}

--- a/src/app/page/home/home.component.html
+++ b/src/app/page/home/home.component.html
@@ -1,2 +1,2 @@
- <app-hello></app-hello>
+<app-hello></app-hello>
 <app-apresentacao></app-apresentacao>


### PR DESCRIPTION
### Motivation
- Add a dedicated Privacy Policy page for the app and render pages using the router instead of a single home include.
- Register the new page in the application module and provide routing and user-friendly redirects (including a typo redirect and a catch-all).

### Description
- Added a new `PoliticaComponent` with `politica.component.ts`, `politica.component.html` and `politica.component.scss` to host the privacy policy content and styling.
- Replaced static `<app-home>` usage with `<router-outlet>` in `app.component.html` to enable route-based navigation.
- Updated `AppRoutingModule` to import `HomeComponent` and `PoliticaComponent`, added routes for `''` (home), `politica`, a redirect from `politoca` to `politica`, and a wildcard redirect to home.
- Registered `PoliticaComponent` in `AppModule` declarations and applied a small formatting fix in `home.component.html`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a73056eb5c83219ee5153f2e406b84)